### PR TITLE
I've corrected critical errors in `UserDao.java`:

### DIFF
--- a/FoodTraceabilitySystemServer25960/src/dao/UserDao.java
+++ b/FoodTraceabilitySystemServer25960/src/dao/UserDao.java
@@ -15,50 +15,70 @@ import org.hibernate.Query;
 
 public class UserDao {
     
-     public String registerUser(User user){
-        try{
-            //1. Create a Session
-            Session ss= HibernateUtil.getSessionFactory().openSession();
-            //2.Create a transaction
-            Transaction tr= ss.beginTransaction();
-            ss.merge(user); // Corrected to merge for update
+    public String registerUser(User user) {
+        Session ss = null;
+        Transaction tr = null;
+        try {
+            ss = HibernateUtil.getSessionFactory().openSession();
+            tr = ss.beginTransaction();
+            ss.save(user); // Correct for new entity
             tr.commit();
-            ss.close();
-            return "Data saved succesfully";
-        }catch(Exception ex){
+            return "Data saved successfully";
+        } catch (Exception ex) {
+            if (tr != null) {
+                tr.rollback();
+            }
             ex.printStackTrace();
+            return "Error saving user: " + ex.getMessage();
+        } finally {
+            if (ss != null) {
+                ss.close();
+            }
         }
-        return null;
     }
-     public String updateUser(User user){
-        try{
-            //1. Create a Session
-            Session ss= HibernateUtil.getSessionFactory().openSession();
-            //2.Create a transaction
-            Transaction tr= ss.beginTransaction();
-            ss.delete(user); // Corrected to delete
+
+    public String updateUser(User user) {
+        Session ss = null;
+        Transaction tr = null;
+        try {
+            ss = HibernateUtil.getSessionFactory().openSession();
+            tr = ss.beginTransaction();
+            ss.merge(user); // Correct for updating detached or existing entity
             tr.commit();
-            ss.close();
-            return "Data updated succesfully";
-        }catch(Exception ex){
+            return "Data updated successfully";
+        } catch (Exception ex) {
+            if (tr != null) {
+                tr.rollback();
+            }
             ex.printStackTrace();
+            return "Error updating user: " + ex.getMessage();
+        } finally {
+            if (ss != null) {
+                ss.close();
+            }
         }
-        return null;
     }
-     public String deleteUser(User user){
-        try{
-            //1. Create a Session
-            Session ss= HibernateUtil.getSessionFactory().openSession();
-            //2.Create a transaction
-            Transaction tr= ss.beginTransaction();
-            ss.save(user);
+
+    public String deleteUser(User user) {
+        Session ss = null;
+        Transaction tr = null;
+        try {
+            ss = HibernateUtil.getSessionFactory().openSession();
+            tr = ss.beginTransaction();
+            ss.delete(user); // Correct for deleting an entity
             tr.commit();
-            ss.close();
-            return "Data deleted succesfully";
-        }catch(Exception ex){
+            return "Data deleted successfully";
+        } catch (Exception ex) {
+            if (tr != null) {
+                tr.rollback();
+            }
             ex.printStackTrace();
+            return "Error deleting user: " + ex.getMessage();
+        } finally {
+            if (ss != null) {
+                ss.close();
+            }
         }
-        return null;
     }
      
       public List<User> retreiveAll(){


### PR DESCRIPTION
- The `updateUser` method was previously calling `delete` and has now been firmly corrected to use `session.merge(user)`. This resolves an issue where users were unintentionally deleted when attempting to update their OTP details.
- The `registerUser` method now correctly uses `session.save(user)`.
- The `deleteUser` method now correctly uses `session.delete(user)`.

Additionally:
- I corrected a typo in the success message string returned by `updateUser` (from "succesfully" to "successfully"). This ensures that client-side checks for this success message work as intended.
- I implemented more robust session and transaction handling in `registerUser`, `updateUser`, and `deleteUser` methods by:
    - Ensuring Hibernate sessions are always closed in a `finally` block.
    - Ensuring transactions are rolled back in `catch` blocks if an exception occurs.
    - Returning more informative error messages from the DAO methods on failure.

These changes are crucial for the stability of user operations and the correct functioning of the OTP feature, particularly preventing accidental user deletion and ensuring accurate feedback on database operations.