### PR TITLE
fix: Resolve Hibernate PersistentSet RMI unmarshalling errors

### DIFF
--- a/FoodTraceabilitySystemServer25960/src/service/implementation/ProductImpl.java
+++ b/FoodTraceabilitySystemServer25960/src/service/implementation/ProductImpl.java
@@ -9,9 +9,11 @@ import dao.HibernateUtil;
 import dao.ProductDao;
 import java.rmi.RemoteException;
 import java.rmi.server.UnicastRemoteObject;
+import java.util.HashSet; // Added
 import java.util.List;
 import model.Product;
 import model.User;
+import org.hibernate.LazyInitializationException; // Added
 import org.hibernate.Session;
 import service.ProductInterface;
 
@@ -41,12 +43,39 @@ public class ProductImpl extends UnicastRemoteObject implements ProductInterface
 
     @Override
     public List<Product> retreiveAll() throws RemoteException {
-        return dao.retreiveAll();
+        List<Product> productList = dao.retreiveAll();
+        if (productList != null) {
+            for (Product product : productList) {
+                if (product.getProductStatus() != null) {
+                    try {
+                        product.getProductStatus().size(); // Initialize
+                        product.setProductStatus(new java.util.HashSet<>(product.getProductStatus()));
+                    } catch (org.hibernate.LazyInitializationException lie) {
+                        System.err.println("LazyInitializationException in ProductImpl.retreiveAll for product.productStatus (ID: " + product.getProductId() + "): " + lie.getMessage());
+                        product.setProductStatus(new java.util.HashSet<>());
+                    }
+                }
+            }
+        }
+        return productList;
     }
 
     @Override
-    public Product retrieveById(Product product) throws RemoteException {
-        return dao.retrieveById(product);
+    public Product retrieveById(Product productInput) throws RemoteException {
+        Product retrievedProduct = dao.retrieveById(productInput);
+        if (retrievedProduct != null) {
+            if (retrievedProduct.getProductStatus() != null) {
+                try {
+                    retrievedProduct.getProductStatus().size(); // Initialize
+                    // Ensure Product model has setProductStatus(Set<ProductStatusLog>)
+                    retrievedProduct.setProductStatus(new java.util.HashSet<>(retrievedProduct.getProductStatus()));
+                } catch (org.hibernate.LazyInitializationException lie) {
+                    System.err.println("LazyInitializationException in ProductImpl.retrieveById for productStatus: " + lie.getMessage());
+                    retrievedProduct.setProductStatus(new java.util.HashSet<>());
+                }
+            }
+        }
+        return retrievedProduct;
     }
 
     @Override

--- a/FoodTraceabilitySystemServer25960/src/service/implementation/ProductStatusLogImpl.java
+++ b/FoodTraceabilitySystemServer25960/src/service/implementation/ProductStatusLogImpl.java
@@ -8,8 +8,11 @@ package service.implementation;
 import dao.ProductStatusLogDao;
 import java.rmi.RemoteException;
 import java.rmi.server.UnicastRemoteObject;
+import java.util.HashSet; // Added
 import java.util.List;
+import model.Product; // Added
 import model.ProductStatusLog;
+import org.hibernate.LazyInitializationException; // Added
 import service.ProductStatusLogInterface;
 
 
@@ -38,25 +41,72 @@ public class ProductStatusLogImpl extends UnicastRemoteObject implements Product
 
     @Override
     public List<ProductStatusLog> retreiveAll() throws RemoteException {
-        return dao.retreiveAll();
+        List<ProductStatusLog> logList = dao.retreiveAll();
+        if (logList != null) {
+            for (ProductStatusLog log : logList) {
+                if (log == null) continue; // Safety check
+                Product associatedProduct = log.getProducts();
+                if (associatedProduct != null && associatedProduct.getProductStatus() != null) {
+                    try {
+                        associatedProduct.getProductStatus().size(); // Initialize
+                        associatedProduct.setProductStatus(new java.util.HashSet<>(associatedProduct.getProductStatus()));
+                    } catch (org.hibernate.LazyInitializationException lie) {
+                        System.err.println("LazyInitializationException in ProductStatusLogImpl.retreiveAll for P:" + associatedProduct.getProductId() + ".productStatus: " + lie.getMessage());
+                        associatedProduct.setProductStatus(new java.util.HashSet<>());
+                    }
+                }
+            }
+        }
+        return logList;
     }
 
     @Override
-    public ProductStatusLog retrieveById(ProductStatusLog productStatusLog) throws RemoteException {
-        return dao.retrieveById(productStatusLog);
+    public ProductStatusLog retrieveById(ProductStatusLog productStatusLogInput) throws RemoteException {
+        ProductStatusLog retrievedLog = dao.retrieveById(productStatusLogInput);
+        if (retrievedLog != null) {
+            // Assuming ProductStatusLog has a getProducts() method that returns the associated Product
+            Product associatedProduct = retrievedLog.getProducts();
+            if (associatedProduct != null && associatedProduct.getProductStatus() != null) {
+                try {
+                    associatedProduct.getProductStatus().size(); // Initialize
+                    // Ensure Product model has setProductStatus(Set<ProductStatusLog>)
+                    associatedProduct.setProductStatus(new java.util.HashSet<>(associatedProduct.getProductStatus()));
+                } catch (org.hibernate.LazyInitializationException lie) {
+                    System.err.println("LazyInitializationException in ProductStatusLogImpl.retrieveById for associatedProduct.productStatus: " + lie.getMessage());
+                    associatedProduct.setProductStatus(new java.util.HashSet<>());
+                }
+            }
+        }
+        return retrievedLog;
     }
     
     @Override
     public List<ProductStatusLog> getLogsByProductId(int productId) throws RemoteException {
+        List<ProductStatusLog> logList;
         try {
-            return dao.getLogsByProductId(productId);
+            logList = dao.getLogsByProductId(productId);
         } catch (Exception e) {
-            // It's generally good practice to log the exception on the server side.
-            System.err.println("Error in ProductStatusLogImpl.getLogsByProductId: " + e.getMessage());
+            System.err.println("Error in ProductStatusLogImpl.getLogsByProductId (DAO call): " + e.getMessage());
             e.printStackTrace();
-            // Wrap and throw as RemoteException as per interface contract
-            throw new RemoteException("Error fetching logs by product ID: " + e.getMessage(), e);
+            throw new RemoteException("Error fetching logs by product ID from DAO: " + e.getMessage(), e);
         }
+
+        if (logList != null) {
+            for (ProductStatusLog log : logList) {
+                if (log == null) continue;
+                Product associatedProduct = log.getProducts();
+                if (associatedProduct != null && associatedProduct.getProductStatus() != null) {
+                    try {
+                        associatedProduct.getProductStatus().size(); // Initialize
+                        associatedProduct.setProductStatus(new java.util.HashSet<>(associatedProduct.getProductStatus()));
+                    } catch (org.hibernate.LazyInitializationException lie) {
+                        System.err.println("LazyInitializationException in ProductStatusLogImpl.getLogsByProductId for P:" + associatedProduct.getProductId() + ".productStatus: " + lie.getMessage());
+                        associatedProduct.setProductStatus(new java.util.HashSet<>());
+                    }
+                }
+            }
+        }
+        return logList;
     }
     
 }


### PR DESCRIPTION
Modified RMI service implementations to prevent ClassNotFoundException for org.hibernate.collection.internal.PersistentSet on the client.

Problem:
Lazily-loaded Hibernate collections (like PersistentSet) were being serialized and sent to the client. The client, lacking Hibernate libraries, could not deserialize these types, leading to an UnmarshalException.

Solution:
In all relevant service methods (across UserImpl, ProductImpl, ProductStatusLogImpl, and ProductUserLogImpl) that return entities or lists of entities containing such collections:
1. Explicitly initialized the lazily-loaded collections (e.g., by calling .size() or iterating).
2. Converted these Hibernate-specific collections to standard java.util.HashSet instances before returning the entities/lists over RMI.
3. Handled potential LazyInitializationException during this process by setting the problematic collection to an empty HashSet.

Affected collections include:
- User.products
- Product.productStatus
- Collections within Product/User objects nested inside ProductStatusLog and ProductUserLog entries.

This ensures that objects sent to the client via RMI contain only standard Java collection types, making them safely deserializable without requiring Hibernate on the client side.