### PR TITLE
fix: Address PersistentSet errors and remove user management admin re…

### DIFF
--- a/FoodTraceabilitySystem/src/view/DashboardForm.java
+++ b/FoodTraceabilitySystem/src/view/DashboardForm.java
@@ -60,7 +60,7 @@ public class DashboardForm extends JFrame {
         styleButton(btnManageProducts, buttonFont, buttonSize, "View and manage existing products.");
 
         btnManageUsers = new JButton("Manage Users");
-        styleButton(btnManageUsers, buttonFont, buttonSize, "Manage user accounts (Admin only).");
+        styleButton(btnManageUsers, buttonFont, buttonSize, "View and manage user accounts."); // Updated tooltip
 
         btnViewProductLogs = new JButton("View Product Activity Logs");
         styleButton(btnViewProductLogs, buttonFont, buttonSize, "View detailed activity logs for products.");
@@ -81,13 +81,11 @@ public class DashboardForm extends JFrame {
         buttonPanel.add(btnManageUsers); // Add here, visibility/enabled state managed below
         buttonPanel.add(btnLogout);
 
-        // Role-Based Visibility/Enablement for "Manage Users"
-        if (currentUser != null && "admin".equalsIgnoreCase(currentUser.getRole())) {
-            btnManageUsers.setEnabled(true);
-        } else {
-            btnManageUsers.setEnabled(false);
-            btnManageUsers.setToolTipText("Manage user accounts (Admin access required).");
-        }
+        // Role-Based Visibility/Enablement for "Manage Users" - REMOVED, button is always enabled
+        btnManageUsers.setEnabled(true);
+        // Tooltip was updated in the styleButton call earlier, or could be set here again if needed.
+        // btnManageUsers.setToolTipText("View and manage user accounts.");
+
 
         mainPanel.add(buttonPanel, BorderLayout.CENTER);
         add(mainPanel);

--- a/FoodTraceabilitySystem/src/view/UserListForm.java
+++ b/FoodTraceabilitySystem/src/view/UserListForm.java
@@ -36,16 +36,7 @@ public class UserListForm extends JFrame {
     public UserListForm(User adminUser) {
         this.currentUser = adminUser;
 
-        if (currentUser == null || !"admin".equalsIgnoreCase(currentUser.getRole())) {
-            JOptionPane.showMessageDialog(null, "Access Denied: Admin role required to manage users.",
-                                          "Access Denied", JOptionPane.ERROR_MESSAGE);
-            // Dispose the frame if access is denied.
-            // Ensure this is called after the constructor finishes or use SwingUtilities.invokeLater
-            SwingUtilities.invokeLater(() -> dispose());
-            // To prevent further initialization if access is denied, we can return early.
-            // However, the frame is already being constructed. A better pattern might be a static factory method.
-            // For now, we let initComponents run but the form will be disposed quickly.
-        }
+        // Removed admin role check block
 
         try {
             userService = RmiClientUtil.getUserService();
@@ -62,11 +53,12 @@ public class UserListForm extends JFrame {
         setMinimumSize(new Dimension(800, 500));
         setLocationRelativeTo(null);
 
-        if (userService != null && (currentUser != null && "admin".equalsIgnoreCase(currentUser.getRole()))) {
+        if (userService != null && currentUser != null) { // Load users if service and user are available, regardless of role
             loadUsers();
+            // All buttons remain enabled by default if service is available
         } else {
-            // Disable components if service failed or user is not admin
-            if (btnAddUser != null) btnAddUser.setEnabled(false);
+            // Disable components if service failed or user is somehow null (though constructor expects a user)
+            if (btnAddUser != null) btnAddUser.setEnabled(false); // Check for null in case initComponents hasn't run
             if (btnEditUser != null) btnEditUser.setEnabled(false);
             if (btnDeleteUser != null) btnDeleteUser.setEnabled(false);
             if (btnSearchUser != null) btnSearchUser.setEnabled(false);

--- a/FoodTraceabilitySystemServer25960/src/service/implementation/ProductImpl.java
+++ b/FoodTraceabilitySystemServer25960/src/service/implementation/ProductImpl.java
@@ -55,6 +55,19 @@ public class ProductImpl extends UnicastRemoteObject implements ProductInterface
                         product.setProductStatus(new java.util.HashSet<>());
                     }
                 }
+
+                // Now handle the User collection within the Product's associated User
+                User associatedUser = product.getUsers(); // Assuming getUsers() is the correct getter
+                if (associatedUser != null && associatedUser.getProducts() != null) {
+                    try {
+                        associatedUser.getProducts().size(); // Force initialization
+                        // Ensure model.User has setProducts(Set<Product>)
+                        associatedUser.setProducts(new java.util.HashSet<>(associatedUser.getProducts()));
+                    } catch (org.hibernate.LazyInitializationException lie) {
+                        System.err.println("LazyInitializationException in ProductImpl.retreiveAll for associatedUser.products (User ID: " + associatedUser.getUserId() + ", Product ID: " + product.getProductId() + "): " + lie.getMessage());
+                        associatedUser.setProducts(new java.util.HashSet<>()); // Set to empty HashSet on error
+                    }
+                }
             }
         }
         return productList;


### PR DESCRIPTION
…striction

This commit includes fixes for RMI UnmarshalExceptions related to org.hibernate.collection.internal.PersistentSet and removes the admin-only restriction for user management features.

1.  **User Management Accessibility:**
    - Modified `DashboardForm.java` to always enable the "Manage Users" button.
    - Modified `UserListForm.java` to remove the constructor check that restricted access to admin users. User management is now accessible to any logged-in user.

2.  **RMI PersistentSet Serialization Fixes:**
    - **`ProductImpl.retreiveAll()`:** Enhanced to ensure that for each `Product` in the returned list, not only is its `productStatus` collection handled (initialized and converted to HashSet), but also the `products` collection of its associated `User` object (`product.getUsers().getProducts()`) is handled. This addresses potential errors when you access this nested collection.
    - **`ProductUserLogImpl.java` (Verification):** Reviewed the existing `processLogCollections` helper method. It already correctly handles the primary collections: `ProductUserLog.getProduct().getProductStatus()` and `ProductUserLog.getUser().getProducts()`. No further changes were made to this class in this commit, assuming the existing implementation is correctly deployed.

These changes aim to improve client-side stability by ensuring Hibernate-specific collections are converted to standard Java types before RMI transmission and to align with the new requirement for general access to user management.