### PR TITLE
fix: Modernize HibernateUtil and improve SessionFactory creation logging

### DIFF
--- a/FoodTraceabilitySystemServer25960/src/dao/HibernateUtil.java
+++ b/FoodTraceabilitySystemServer25960/src/dao/HibernateUtil.java
@@ -5,7 +5,8 @@
  */
 package dao;
 
-import org.hibernate.cfg.AnnotationConfiguration;
+// import org.hibernate.cfg.AnnotationConfiguration; // Old import
+import org.hibernate.cfg.Configuration; // New import
 import org.hibernate.SessionFactory;
 
 /**
@@ -21,11 +22,20 @@ public class HibernateUtil {
     static {
         try {
             // Create the SessionFactory from standard (hibernate.cfg.xml) 
-            // config file.
-            sessionFactory = new AnnotationConfiguration().configure().buildSessionFactory();
+            // config file using modern Configuration class.
+            sessionFactory = new Configuration().configure().buildSessionFactory();
+
+            // Log the state of sessionFactory from HibernateUtil's perspective
+            if (sessionFactory == null) {
+                System.err.println("HibernateUtil: SessionFactory is NULL immediately after buildSessionFactory!");
+            } else {
+                System.out.println("HibernateUtil: SessionFactory created successfully. Is open: " + !sessionFactory.isClosed());
+            }
+
         } catch (Throwable ex) {
             // Log the exception. 
             System.err.println("Initial SessionFactory creation failed." + ex);
+            ex.printStackTrace(); // Print stack trace for detailed diagnostics
             throw new ExceptionInInitializerError(ex);
         }
     }


### PR DESCRIPTION
Updated `FoodTraceabilitySystemServer25960/src/dao/HibernateUtil.java`:
- Changed SessionFactory creation from the deprecated `org.hibernate.cfg.AnnotationConfiguration` to the standard `org.hibernate.cfg.Configuration`. This aligns with Hibernate 4.x+ best practices.
- Added explicit logging immediately after the `sessionFactory` assignment to print to console whether the SessionFactory was created successfully or is null from HibernateUtil's perspective.
- Enhanced the catch block for SessionFactory creation to print the full stack trace (`ex.printStackTrace()`) for better diagnostics if initialization fails.

These changes aim to resolve potential issues with SessionFactory initialization that might have led to a "Configured SessionFactory: null" log message from Hibernate and subsequent QuerySyntaxExceptions. The enhanced logging will provide clearer insight into the SessionFactory's state during server startup.